### PR TITLE
Fix import of pywintypes

### DIFF
--- a/build-scripts/python-site-packages/fetch-pywin32.cmd
+++ b/build-scripts/python-site-packages/fetch-pywin32.cmd
@@ -31,7 +31,7 @@
 
 @cd %SRC_ROOT%\PLATLIB
 @set PYTHON_SITE_PACKAGES=%PYTHON_INSTALL_ROOT%\Lib\site-packages
-@set INSTALL_DIRS=adodbapi isapi win32 win32com win32comext
+@set INSTALL_DIRS=adodbapi isapi pywin32_system32 win32 win32com win32comext
 for %%D in (%INSTALL_DIRS%) do (
   xcopy %%D %PYTHON_SITE_PACKAGES%\%%D /Y /I /E
 )
@@ -39,6 +39,12 @@ for %%D in (%INSTALL_DIRS%) do (
 @set INSTALL_FILES=pythoncom.py pywin32.pth pywin32.version.txt pywin32-219-py2.7.egg-info
 for %%F in (%INSTALL_FILES%) do (
   xcopy %%F %PYTHON_SITE_PACKAGES%\ /Y /I
+)
+
+:: By default the DLLs are put in the wrong place - move them
+@set DLL_FILES=pywintypes27.dll pythoncom27.dll pythoncomloader27.dll
+for %%F in (%DLL_FILES%) do (
+  xcopy %PYTHON_SITE_PACKAGES%\pywin32_system32\%%F %PYTHON_SITE_PACKAGES%\win32\lib /Y /I
 )
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/lib/python2.7/Lib/site-packages/win32/lib/pythoncom27.dll
+++ b/lib/python2.7/Lib/site-packages/win32/lib/pythoncom27.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27b00bb3ac1c043e35f039bf0d365066798c937a9a318d431fd27d209d9cf79b
+size 548864

--- a/lib/python2.7/Lib/site-packages/win32/lib/pythoncomloader27.dll
+++ b/lib/python2.7/Lib/site-packages/win32/lib/pythoncomloader27.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b7f50a3af435f60de441ba68561cee2f0d5b2e1a502a58b3b34cd2b3a5ba8f6
+size 8704

--- a/lib/python2.7/Lib/site-packages/win32/lib/pywintypes27.dll
+++ b/lib/python2.7/Lib/site-packages/win32/lib/pywintypes27.dll
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b73dff24ab68e01b175467556dcf0614443273616ad24623899daa1eb796af1f
+size 137728


### PR DESCRIPTION
The DLLs for pywintypes are in the `pywin32_system32` directory. Add this to list of install directories and then move the DLLs into `win32\lib`.

To test:
- Run the `fetch-pywin32.cmd` script on Windows
- Start Python and `import pywintypes`
- No import error should be seen