### PR TITLE
Fix TBB using _DEBUG macro value instead of 1

### DIFF
--- a/build-scripts/extras/tbb/tbb_config-debug.patch
+++ b/build-scripts/extras/tbb/tbb_config-debug.patch
@@ -1,0 +1,14 @@
+diff --git tbb/tbb_config.h tbb/tbb_config.h
+index 79d3d23..f3a8d43 100644
+--- tbb/tbb_config.h
++++ tbb/tbb_config.h
+@@ -298,7 +299,8 @@
+ 
+ #ifndef TBB_USE_DEBUG
+ #ifdef _DEBUG
+-#define TBB_USE_DEBUG _DEBUG
++// Explicitly set TBB_USE_DEBUG to 1 instead of using value in _DEBUG
++#define TBB_USE_DEBUG 1
+ #else
+ #define TBB_USE_DEBUG 0
+ #endif

--- a/build-scripts/fetch-tbb.cmd
+++ b/build-scripts/fetch-tbb.cmd
@@ -8,6 +8,7 @@
 :: Setup environment. Important to ensure correct detection of environment
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 @call %~dp0cmds\common-setup.cmd
+@set TBB_EXTRAS_DIR=%dp0extras\tbb
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Download
@@ -43,6 +44,13 @@ xcopy lib\%VC_DIR% %INSTALL_ROOT%\lib /Y /I
 
 :: Runtime DLLs
 xcopy bin\%VC_DIR% %INSTALL_ROOT%\bin /Y /I
+
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Patch
+::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+@echo Patching Intel TBB
+cd %BUILD_DIR%
+call patch -p0 --input=%TBB_EXTRAS_DIR%\tbb_config-debug.patch
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Post-process

--- a/include/tbb/tbb_config.h
+++ b/include/tbb/tbb_config.h
@@ -298,7 +298,7 @@
 
 #ifndef TBB_USE_DEBUG
 #ifdef _DEBUG
-#define TBB_USE_DEBUG _DEBUG
+#define TBB_USE_DEBUG 1
 #else
 #define TBB_USE_DEBUG 0
 #endif

--- a/include/tbb/tbb_config.h
+++ b/include/tbb/tbb_config.h
@@ -298,6 +298,7 @@
 
 #ifndef TBB_USE_DEBUG
 #ifdef _DEBUG
+// Explicitly set TBB_USE_DEBUG to 1 instead of using value in _DEBUG
 #define TBB_USE_DEBUG 1
 #else
 #define TBB_USE_DEBUG 0


### PR DESCRIPTION
This fixes an issue with TBB attempting to use the value of `_DEBUG` to set `TBB_USE_DEBUG` instead of setting it to 1. 
Currently `_DEBUG` is undefined then redefined by the Boost Python Libraries so loses its value of 1 causing the error "Invalid constant expression" 