### PR TITLE
Add code to find a sitecustomize.py file in bin/<config> directory

### DIFF
--- a/lib/python3.8/Lib/site-packages/sitecustomize.py
+++ b/lib/python3.8/Lib/site-packages/sitecustomize.py
@@ -7,6 +7,7 @@ This bundle is assumed to only be used on Windows. This trick is based on the si
 in PyQt5.__init__.
 """
 
+
 def find_thirdparty():
     import os, sys
 
@@ -41,3 +42,24 @@ def find_thirdparty():
 
 find_thirdparty()
 del find_thirdparty
+
+"""
+Based on: https://code.activestate.com/recipes/552729/
+Since Python 2.5 the path of the .py file being run (=cwd) seems to be added to sys.path somewhere
+later after importing the file "site". The only case where this isn't true is running workbench
+via the PyCharm pydevd script
+So "sitecustomize.py" file is just found on the default path. Add the current working directory
+to the sys.path here to give a better chance of a Mantid sitecustomize in bin/<Config> being found
+Note - cwd not guaranteed to be bin/<Config> if workbench not started via "python script.py" so
+don't do the addsitedir calls here
+The mantid sitecustomize has a suffix in the name to ensure it never hides this sitecustomize.py
+This code may also be run at cmake configure time in which case the sitecustomize_mantid.py may
+not have been created yet so don't fail if can't import it
+"""
+import sys
+import os
+sys.path = [os.getcwd()] + sys.path
+try:
+    import sitecustomize_mantid
+except ImportError:
+    pass


### PR DESCRIPTION
This isn't complete yet - but here's an attempt to fix two problems with the setuptools develop mode on setuptools>49.0.0:

1) this sorts out the clash between the two sitecustomize.py files when running with setuptools>=49.0.0 on Windows. Prior to these changes only one of the two sitecustomize.py files gets read (the one that "wins" depends on the method used to start up workbench eg running Mantid using the Run, Debug menu results in the `bin/<config>/sitecustomize.py` being read whereas most other routes only read the `site-packages/sitecustomize.py` file

2) the new lines will (I believe) also be needed on other platforms when they update to python 3.8. In that version the .egg-link files will no longer be found\read. Also the `bin/<config>/sitecustomize.py` file won't be found either. So the code won't have any way of finding the python packages in the source code directories when running in develop mode

Because of 2) I think this file may need to be created in cmake and written to the python site-packages directory rather than being kept in this Windows specific repository. **So this isn't ready\finished yet**

I have another small change in the main Mantid repository to rename the `bin/<config>/sitecustomize.py` to sitecustomize_mantid.py and to add a few comments - but that side of things is more trivial so far.

Problem described in [#33118](https://github.com/mantidproject/mantid/issues/33118)