### PR TITLE
Fix problem compiling Mantid in Debug on VS2022

### DIFF
--- a/build-scripts/extras/python/wrappython.h
+++ b/build-scripts/extras/python/wrappython.h
@@ -31,6 +31,12 @@
 
 #ifdef _DEBUG
 # ifndef MANTID_DEBUG_PYTHON
+// Workaround for VS 2022 which doesn't like _DEBUG being messed with. Based on PyBind solution
+// https://github.com/pybind/pybind11/pull/3497
+#  include<yvals.h>
+#  if _MSVC_STL_VERSION >= 143
+#      include <crtdefs.h>
+#  endif
 #  undef _DEBUG // Don't let Python force the debug library just because we're debugging.
 #  define DEBUG_UNDEFINED_FROM_WRAP_PYTHON_H
 # endif

--- a/lib/python3.8/include/wrappython.h
+++ b/lib/python3.8/include/wrappython.h
@@ -31,6 +31,12 @@
 
 #ifdef _DEBUG
 # ifndef MANTID_DEBUG_PYTHON
+// Workaround for VS 2022 which doesn't like _DEBUG being messed with. Based on PyBind solution
+// https://github.com/pybind/pybind11/pull/3497
+#  include<yvals.h>
+#  if _MSVC_STL_VERSION >= 143
+#      include <crtdefs.h>
+#  endif
 #  undef _DEBUG // Don't let Python force the debug library just because we're debugging.
 #  define DEBUG_UNDEFINED_FROM_WRAP_PYTHON_H
 # endif


### PR DESCRIPTION
This resolves a problem generating a debug build of Mantid in VS2022. The build failed with errors like:
```
error C2039: '_invalid_parameter': is not a member of '`global namespace''
error C3861: '_invalid_parameter': identifier not found
```
Fix is based on similar problem PyBind were having:
https://github.com/pybind/pybind11/pull/3497

The updated file also exists in build-scripts\extras\python\wrappython.h. Not sure if I should also update this?